### PR TITLE
Replace existing prerelease suffix

### DIFF
--- a/action.js
+++ b/action.js
@@ -79,7 +79,7 @@ function determineContinuousBumpType(semTag) {
 function determinePrereleaseName(semTag) {
   const hasExistingPrerelease = semTag.prerelease.length > 0
 
-  if (hasExistingPrerelease) {
+  if (hasExistingPrerelease && core.getInput('prerelease_suffix') <= 0) {
     const [name, _] = semTag.prerelease
     return name
   } else {

--- a/action.js
+++ b/action.js
@@ -79,7 +79,7 @@ function determineContinuousBumpType(semTag) {
 function determinePrereleaseName(semTag) {
   const hasExistingPrerelease = semTag.prerelease.length > 0
 
-  if (hasExistingPrerelease && (!(core.getInput('prerelease_suffix'))) {
+  if (hasExistingPrerelease && !core.getInput('prerelease_suffix')) {
     const [name, _] = semTag.prerelease
     return name
   } else {

--- a/action.js
+++ b/action.js
@@ -79,7 +79,7 @@ function determineContinuousBumpType(semTag) {
 function determinePrereleaseName(semTag) {
   const hasExistingPrerelease = semTag.prerelease.length > 0
 
-  if (hasExistingPrerelease && core.getInput('prerelease_suffix') <= 0) {
+  if (hasExistingPrerelease && (!(core.getInput('prerelease_suffix'))) {
     const [name, _] = semTag.prerelease
     return name
   } else {


### PR DESCRIPTION
When a prerelease suffix has not been specified use the existing suffix, then use the default when no existing suffix is found.

When a prelease suffix has been specified use this suffix to override both existing and default suffix.

This would allow the behavior of creating alpha releases, moving to beta releases etc. without manually creating a tag to change future suffix. This also ensures changes in these tags are consistent, formatting etc.

Example:
Repo with existing last tag **v0.1.0-alpha.12**

```
Run ./.github/actions/compute-tag
  with:
    github_token: ***
    version_scheme: semantic
    version_type: prerelease
    prerelease_suffix: beta

Computing the next tag based on: v0.1.0-alpha.12
Computed the next tag as: v0.1.0-beta.0 
```