### PR TITLE
Fix repos.listCommits

### DIFF
--- a/action.js
+++ b/action.js
@@ -89,7 +89,7 @@ async function existingTags() {
 }
 
 async function latestTagForBranch(allTags, branch) {
-  const options = gitClient.repos.listCommits.endpoint.merge({
+  const options = gitClient.rest.repos.listCommits.endpoint.merge({
     ...requestOpts,
     sha: branch,
   })


### PR DESCRIPTION
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`072ad47`](https://github.com/craig-day/compute-tag/pull/16/commits/072ad4739e6a22efbb2ba92a2e5cbe2875aa2333) Fix repos.listCommits

It was moved into gitClient.rest.


<!-- === GH HISTORY FENCE === -->

Sorry, missed this one in my last PR.


<img width="802" alt="image" src="https://user-images.githubusercontent.com/4507647/210463404-7d4e24d6-e119-4e1c-b6f2-447ab290a039.png">
