### PR TITLE
Fix version bump from a non-prerelease

### DIFF
--- a/action.js
+++ b/action.js
@@ -131,12 +131,12 @@ function semanticVersion(tag) {
     const [version, pre] = tag.split('-', 2)
     const sem = semver.parse(semver.coerce(version))
 
-    // reset the raw string values tracked in the object to ensure future
-    // calculations are performed correctly
-    sem.raw = `${sem.raw}-${pre}`
-    sem.version = `${sem.version}-${pre}`
-    
     if (!isNullString(pre)) {
+      // reset the raw string values tracked in the object to ensure future
+      // calculations are performed correctly
+      sem.raw = `${sem.raw}-${pre}`
+      sem.version = `${sem.version}-${pre}`
+
       sem.prerelease = semver.prerelease(`0.0.0-${pre}`)
     }
 


### PR DESCRIPTION
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`d061909`](https://github.com/craig-day/compute-tag/pull/18/commits/d06190958572785aeff6974ccd426cf70f1a79b4) Fix non-prerelease version bump

When last tag wasn't a prerelease, sem.raw and sem.version are set to
123-undefined. This leads semver.inc() to return the same version.


<!-- === GH HISTORY FENCE === -->
