### PR TITLE
Increases page size used when listing commits

### DIFF
--- a/action.js
+++ b/action.js
@@ -91,6 +91,10 @@ async function existingTags() {
 async function latestTagForBranch(allTags, branch) {
   const options = gitClient.rest.repos.listCommits.endpoint.merge({
     ...requestOpts,
+    // Set pagination per_page param to max allowed (100).
+    // Default is 30 per page, which can hit rate limits on repositories with
+    // a lot of commits.
+    per_page: 100,
     sha: branch,
   })
 


### PR DESCRIPTION
I've recently run into rate limits when using this action on a repository with over 180k commits:

```
Rate limit exceeded for GET https://api.github.com/repos/my_repo/commits?sha=refs%2Fheads%2Fmain
```

By default, `@octokit/plugin-paginate-rest` paginates at 30 items per page.

This commit increases that to the maximum supported value of 100 items per page to lower chances of running into rate limits.

From the [octokit docs](https://www.npmjs.com/package/@octokit/plugin-paginate-rest):

> The per_page parameter is usually defaulting to 30, and can be set to up to 100, which helps retrieving a big amount of data without hitting the rate limits too soon.

Thanks for considering this PR!