### PR TITLE
fix initial tag computation

### DIFF
--- a/action.js
+++ b/action.js
@@ -56,7 +56,7 @@ function initialTag(tag) {
   const suffix = core.getInput('prerelease_suffix')
   const newTag = isPrerelease ? `${tag}-${suffix}` : tag
 
-  return `${newTag}.0`
+  return `${newTag}`
 }
 
 async function existingTags() {


### PR DESCRIPTION
When calling github action for first time we get wrong initial tag computed.
Examples:

- `INPUT_GITHUB_TOKEN=$(gh auth token) INPUT_TAG_FETCH_DEPTH=10 INPUT_VERSION_TYPE=major INPUT_VERSION_SCHEME=semantic GITHUB_REPOSITORY=test_repo`

gives 1.0.0.0 while expected version would be 1.0.0

- `INPUT_GITHUB_TOKEN=$(gh auth token) INPUT_TAG_FETCH_DEPTH=10 INPUT_VERSION_TYPE=major INPUT_VERSION_SCHEME=continuous GITHUB_REPOSITORY=test_repo`

gives v1.0 while expected version would be v1

resolves #9