### PR TITLE
bump node version from 16 to 20, bump checkout action to v4 to resolve node deprecation warnings

### DIFF
--- a/.github/workflows/example-runs.yml
+++ b/.github/workflows/example-runs.yml
@@ -26,7 +26,7 @@ jobs:
           - null
           - sample-branch
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - id: compute_tag
         uses: ./

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - id: compute_tag
         uses: ./

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
   icon: tag
 
 runs:
-  using: node16
+  using: node20
   main: action.js
 
 inputs:


### PR DESCRIPTION
As title states, this bumps the node version from 16 -> 20 as node 16 is deprecated: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/