### PR TITLE
Fix tag selection to use highest version instead of first match

### DIFF
--- a/action.js
+++ b/action.js
@@ -115,14 +115,28 @@ async function latestTagForBranch(allTags, branch) {
     })
     .then((commits) => {
       core.info(`Fetched ${commits.length} commits`)
-      let latestTag
 
+      // Find all tags that match commits on this branch
+      const matchingTags = []
       for (const commit of commits) {
-        latestTag = allTags.find((tag) => tag.object.sha === commit.sha)
-        if (latestTag) break
+        const tag = allTags.find((tag) => tag.object.sha === commit.sha)
+        if (tag) {
+          matchingTags.push(tag)
+        }
       }
 
-      return latestTag
+      if (matchingTags.length === 0) {
+        return null
+      }
+
+      // Return the tag with the highest version number
+      return matchingTags.reduce((highest, tag) => {
+        const highestSem = semanticVersion(highest.ref)
+        const tagSem = semanticVersion(tag.ref)
+        if (!highestSem) return tag
+        if (!tagSem) return highest
+        return semver.compare(tagSem, highestSem) > 0 ? tag : highest
+      })
     })
     .catch((e) => {
       core.setFailed(`Failed to fetch commits for branch '${branch}' : ${e}`)


### PR DESCRIPTION
When a branch is specified, the action now selects the tag with the highest semantic version from all matching tags, rather than the first tag encountered during commit traversal

## Problem

When multiple tags exist within the fetched commit range, the action was returning the first tag encountered during git's commit traversal order. This caused incorrect "next tag" computation when PRs merged close together, because git's topological sort order doesn't match version number order.

**Example:** Tags v26880 and v26881 both exist on `main`, but v26880's commit appears at position 16 in the traversal while v26881's commit appears at position 22. The old code would find v26880 first, then compute v26881 as the "next" tag—even though v26881 already exists.

## Solution

Instead of returning the first matching tag, collect all tags that match commits in the fetched range and use `semver.compare()` to return the one with the highest version number.

## Test plan

- [x] Tested locally against `zendesk/help_center` repo which was exhibiting this bug
- Before fix: `previous_tag: v26880` → `next_tag: v26881` (wrong, v26881 exists)
- After fix: `previous_tag: v26881` → `next_tag: v26882` (correct)