### PR TITLE
feat: add tag_prefix input for scoped tag discovery

### DIFF
--- a/action.js
+++ b/action.js
@@ -87,7 +87,7 @@ async function existingTags() {
     })
 }
 
-async function latestTagForBranch(allTags, branch) {
+async function latestTagForBranch(allTags, branch, tagPrefix = '') {
   const options = gitClient.rest.repos.listCommits.endpoint.merge({
     ...requestOpts,
     // Set pagination per_page param to max allowed (100).
@@ -131,8 +131,8 @@ async function latestTagForBranch(allTags, branch) {
 
       // Return the tag with the highest version number
       return matchingTags.reduce((highest, tag) => {
-        const highestSem = semanticVersion(highest.ref)
-        const tagSem = semanticVersion(tag.ref)
+        const highestSem = semanticVersion(highest.ref, tagPrefix)
+        const tagSem = semanticVersion(tag.ref, tagPrefix)
         if (!highestSem) return tag
         if (!tagSem) return highest
         return semver.compare(tagSem, highestSem) > 0 ? tag : highest
@@ -143,9 +143,13 @@ async function latestTagForBranch(allTags, branch) {
     })
 }
 
-function semanticVersion(tag) {
+function semanticVersion(tag, prefix = '') {
   try {
-    const [version, pre] = tag.split('-', 2)
+    let cleanTag = tag
+    if (prefix && cleanTag.startsWith(prefix)) {
+      cleanTag = cleanTag.slice(prefix.length)
+    }
+    const [version, pre] = cleanTag.split('-', 2)
     const sem = semver.parse(semver.coerce(version))
 
     if (!isNullString(pre)) {
@@ -227,9 +231,9 @@ function computeNextSemantic(semTag) {
   }
 }
 
-async function findMatchingLastTag(tags, branch = null) {
+async function findMatchingLastTag(tags, branch = null, tagPrefix = '') {
   if (branch) {
-    const latestTag = await latestTagForBranch(tags, branch)
+    const latestTag = await latestTagForBranch(tags, branch, tagPrefix)
 
     if (latestTag) {
       return latestTag.ref.replace('refs/tags/', '')
@@ -241,14 +245,18 @@ async function findMatchingLastTag(tags, branch = null) {
   }
 }
 
-async function computeLastTag(givenTag, branch = null) {
+async function computeLastTag(givenTag, branch = null, tagPrefix = '') {
   if (isNullString(givenTag)) {
-    const recentTags = await existingTags()
+    let recentTags = await existingTags()
+
+    if (tagPrefix) {
+      recentTags = recentTags.filter(t => t.ref.startsWith(tagPrefix))
+    }
 
     if (recentTags.length < 1) {
       return null
     } else {
-      return findMatchingLastTag(recentTags, branch).catch((error) => {
+      return findMatchingLastTag(recentTags, branch, tagPrefix).catch((error) => {
         core.setFailed(`Failed to find matching last tag with error ${error}`)
       })
     }
@@ -261,16 +269,17 @@ async function computeNextTag() {
   const scheme = core.getInput('version_scheme')
   const branch = core.getInput('branch')
   const givenTag = core.getInput('tag')
+  const tagPrefix = core.getInput('tag_prefix')
 
-  const lastTag = await computeLastTag(givenTag, branch)
+  const lastTag = await computeLastTag(givenTag, branch, tagPrefix)
 
   // Handle zero-state where no tags exist for the repo
   if (!lastTag) {
     switch (scheme) {
       case Scheme.Continuous:
-        return initialTag('v1')
+        return initialTag(`${tagPrefix || 'v'}1`)
       case Scheme.Semantic:
-        return initialTag('v1.0.0')
+        return initialTag(`${tagPrefix || 'v'}1.0.0`)
       default:
         core.setFailed(`Unsupported version scheme: ${scheme}`)
         return
@@ -280,13 +289,13 @@ async function computeNextTag() {
   core.info(`Computing the next tag based on: ${lastTag}`)
   core.setOutput('previous_tag', lastTag)
 
-  const semTag = semanticVersion(lastTag)
+  const semTag = semanticVersion(lastTag, tagPrefix)
 
   if (semTag == null) {
     core.setFailed(`Failed to parse tag: ${lastTag}`)
     return
   } else {
-    semTag.options.tagPrefix = lastTag.startsWith('v') ? 'v' : ''
+    semTag.options.tagPrefix = tagPrefix || (lastTag.startsWith('v') ? 'v' : '')
   }
 
   switch (scheme) {

--- a/action.js
+++ b/action.js
@@ -5,6 +5,7 @@ const process = require('process')
 const { throttling } = require('@octokit/plugin-throttling')
 const { retry } = require('@octokit/plugin-retry')
 const { Octokit } = require('@octokit/core');
+const { isNullString, semanticVersion } = require('./lib')
 
 const GitClient = github.GitHub.plugin(throttling, retry)
 
@@ -43,12 +44,6 @@ const Semantic = {
   Preminor: 'preminor',
   Prepatch: 'prepatch',
   Prerelease: 'prerelease',
-}
-
-function isNullString(string) {
-  return (
-    !string || string.length == 0 || string == 'null' || string == 'undefined'
-  )
 }
 
 function initialTag(tag) {
@@ -141,31 +136,6 @@ async function latestTagForBranch(allTags, branch, tagPrefix = '') {
     .catch((e) => {
       core.setFailed(`Failed to fetch commits for branch '${branch}' : ${e}`)
     })
-}
-
-function semanticVersion(tag, prefix = '') {
-  try {
-    let cleanTag = tag
-    if (prefix && cleanTag.startsWith(prefix)) {
-      cleanTag = cleanTag.slice(prefix.length)
-    }
-    const [version, pre] = cleanTag.split('-', 2)
-    const sem = semver.parse(semver.coerce(version))
-
-    if (!isNullString(pre)) {
-      // reset the raw string values tracked in the object to ensure future
-      // calculations are performed correctly
-      sem.raw = `${sem.raw}-${pre}`
-      sem.version = `${sem.version}-${pre}`
-
-      sem.prerelease = semver.prerelease(`0.0.0-${pre}`)
-    }
-
-    return sem
-  } catch (_) {
-    // semver will return null if it fails to parse, maintain this behavior in our API
-    return null
-  }
 }
 
 function determineContinuousBumpType(semTag) {

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,12 @@ inputs:
     description: What to annotate a prerelease version tag with.
     required: false
     default: 'beta'
+  tag_prefix:
+    description: >
+      Prefix for tags. When set, only tags starting with this prefix are considered
+      for version computation, and the prefix is applied to the computed next tag.
+      When unset, existing behavior is preserved (auto-detects 'v' prefix).
+    required: false
 
 outputs:
   next_tag:

--- a/lib.js
+++ b/lib.js
@@ -1,0 +1,30 @@
+const semver = require('semver')
+
+function isNullString(string) {
+  return (
+    !string || string.length == 0 || string == 'null' || string == 'undefined'
+  )
+}
+
+function semanticVersion(tag, prefix = '') {
+  try {
+    let cleanTag = tag
+    if (prefix && cleanTag.startsWith(prefix)) {
+      cleanTag = cleanTag.slice(prefix.length)
+    }
+    const [version, pre] = cleanTag.split('-', 2)
+    const sem = semver.parse(semver.coerce(version))
+
+    if (!isNullString(pre)) {
+      sem.raw = `${sem.raw}-${pre}`
+      sem.version = `${sem.version}-${pre}`
+      sem.prerelease = semver.prerelease(`0.0.0-${pre}`)
+    }
+
+    return sem
+  } catch (_) {
+    return null
+  }
+}
+
+module.exports = { isNullString, semanticVersion }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "action.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test test.js"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -1,0 +1,76 @@
+const { describe, it } = require('node:test')
+const assert = require('node:assert/strict')
+const { semanticVersion, isNullString } = require('./lib')
+
+describe('isNullString', () => {
+  for (const val of [null, undefined, '', 'null', 'undefined']) {
+    it(`returns true for ${JSON.stringify(val)}`, () => assert.ok(isNullString(val)))
+  }
+  it('returns false for real strings', () => assert.ok(!isNullString('v1.0.0')))
+})
+
+describe('semanticVersion', () => {
+  it('parses v-prefixed tags', () => {
+    const sem = semanticVersion('v1.2.3')
+    assert.equal(sem.major, 1)
+    assert.equal(sem.minor, 2)
+    assert.equal(sem.patch, 3)
+  })
+
+  it('parses tags without prefix', () => {
+    const sem = semanticVersion('1.2.3')
+    assert.equal(sem.major, 1)
+  })
+
+  it('parses prerelease tags', () => {
+    const sem = semanticVersion('v1.0.0-beta.1')
+    assert.equal(sem.major, 1)
+    assert.deepEqual(sem.prerelease, ['beta', 1])
+  })
+
+  it('parses continuous tags', () => {
+    const sem = semanticVersion('v1000')
+    assert.equal(sem.major, 1000)
+  })
+
+  it('returns null for garbage', () => {
+    assert.equal(semanticVersion('not-a-version'), null)
+  })
+
+  describe('with prefix', () => {
+    it('strips prefix before parsing', () => {
+      const sem = semanticVersion('e2e-v1.2.3', 'e2e-')
+      assert.equal(sem.major, 1)
+      assert.equal(sem.minor, 2)
+      assert.equal(sem.patch, 3)
+    })
+
+    it('strips multi-segment prefix', () => {
+      const sem = semanticVersion('test-release-v5.0.0', 'test-release-')
+      assert.equal(sem.major, 5)
+    })
+
+    it('handles prefixed prerelease tags', () => {
+      const sem = semanticVersion('e2e-v2.0.0-rc.1', 'e2e-')
+      assert.equal(sem.major, 2)
+      assert.deepEqual(sem.prerelease, ['rc', 1])
+    })
+
+    it('returns null when prefix present but version is garbage', () => {
+      assert.equal(semanticVersion('e2e-notaversion', 'e2e-'), null)
+    })
+
+    it('still parses when tag does not start with prefix', () => {
+      const sem = semanticVersion('v3.0.0', 'e2e-')
+      assert.equal(sem.major, 3)
+    })
+
+    it('handles empty prefix same as no prefix', () => {
+      const a = semanticVersion('v1.0.0', '')
+      const b = semanticVersion('v1.0.0')
+      assert.equal(a.major, b.major)
+      assert.equal(a.minor, b.minor)
+      assert.equal(a.patch, b.patch)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Release branches used for e2e testing need their own tag namespace to avoid colliding with production version tags on the default branch. Without prefix support, compute-tag discovers all tags globally and produces versions that conflict with the main release series.

The new `tag_prefix` input scopes the entire tag computation pipeline. When set, only tags starting with the prefix are considered, the prefix is stripped before semver parsing, and re-applied to the computed `next_tag` output. When unset, existing behavior is fully preserved (auto-detection of the `v` prefix).

This is the compute-tag side of a broader cicd-toolkit change to support per-ref release configuration, enabling e2e release testing on non-default branches.

## Changes

- `action.yml`: new optional `tag_prefix` input
- `action.js`: prefix threaded through `computeLastTag` -> `findMatchingLastTag` -> `latestTagForBranch` -> `semanticVersion`, with filtering in tag discovery, prefix stripping in semver parsing, and prefix application in zero-state initial tags

## Test plan

- [x] Verify existing behavior unchanged when `tag_prefix` is not set (repos using `compute-tag` today should see no difference)
- [x] Test with a custom prefix (e.g., `e2e-`) on a repo with both prefixed and unprefixed tags - only prefixed tags should be discovered
- [x] Test zero-state with a prefix (no existing tags matching prefix) - should produce `{prefix}1.0.0`
- [x] Test with branch scoping (`branch` + `tag_prefix` together)