### PR TITLE
Migrate to the Node 24 Actions runtime

### DIFF
--- a/.github/workflows/example-runs.yml
+++ b/.github/workflows/example-runs.yml
@@ -26,7 +26,7 @@ jobs:
           - null
           - sample-branch
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - id: compute_tag
         uses: ./

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           version_type: prerelease
 
       - name: create release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           name: ${{ steps.compute_tag.outputs.next_tag }}
           tag_name: ${{ steps.compute_tag.outputs.next_tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - id: compute_tag
         uses: ./

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
   icon: tag
 
 runs:
-  using: node20
+  using: node24
   main: action.js
 
 inputs:


### PR DESCRIPTION
GitHub [announced](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) the deprecation of the Node.js 20 runtime on Actions runners. Workflows using this action now emit:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: craig-day/compute-tag@v20.
```

This PR migrates the action and its CI to the Node 24 runtime:

- **`action.yml`**: `runs.using` `node20` → `node24` (analogous to the Node 16 → 20 bump in #24).
- **`actions/checkout`**: `v4` → `v6` (v5+ targets the Node 24 runtime).
- **`softprops/action-gh-release`**: `v1` → `v3` (v3 moves its runtime to Node 24).

The action only depends on `@actions/*`, `@octokit/*`, and `semver`, all of which run on Node 24.

### Validation

- Unit tests pass on Node 24 (v24.16.0): `node --test test.js` → 17/17.
- The full `Example Runs` matrix (100 jobs: continuous/semantic × major/minor/patch/prerelease × tag prefixes × branches) passes on a Node 24 runner. Run: https://github.com/whhjdi/compute-tag/actions/runs/26947174991

Thanks for maintaining this action!